### PR TITLE
[FE]認証周りのUI作成

### DIFF
--- a/src/components/atoms/Heading/admin/index.stories.tsx
+++ b/src/components/atoms/Heading/admin/index.stories.tsx
@@ -1,0 +1,15 @@
+import { StoryObj } from "@storybook/react";
+import { AdminHeading } from ".";
+
+const meta = {
+  title: 'atoms/Heading/admin',
+  component:  AdminHeading,
+}
+
+export default meta;
+
+type Story = StoryObj<typeof AdminHeading>;
+
+export const PlainHeading: Story = {
+  render: () => <AdminHeading />
+}

--- a/src/components/atoms/Heading/admin/index.tsx
+++ b/src/components/atoms/Heading/admin/index.tsx
@@ -1,0 +1,11 @@
+import { Routing } from "@/hooks/routing";
+import Link from "next/link";
+
+export const AdminHeading = (): JSX.Element => (
+  <h1 className="font-bold text-xl">
+    {/* TODO: まだpathが決まってないので後で変更する */}
+    <Link href={'/'}>
+      Fill Home(Admin)
+    </Link>
+  </h1>
+)

--- a/src/components/atoms/Heading/user/index.stories.tsx
+++ b/src/components/atoms/Heading/user/index.stories.tsx
@@ -3,7 +3,7 @@ import { Heading } from ".";
 
 
 const meta = {
-  title: 'atoms/Heading',
+  title: 'atoms/Heading/user',
   component:  Heading,
 }
 

--- a/src/components/atoms/Heading/user/index.tsx
+++ b/src/components/atoms/Heading/user/index.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 
 export const Heading = (): JSX.Element => (
   <h1 className="font-bold text-xl">
-    {/* TODO: 変更する */}
     <Link href={Routing.rentalHouses.buildRoute().path}>
       Fill Home
     </Link>

--- a/src/components/layouts/Header/UserHeader/index.tsx
+++ b/src/components/layouts/Header/UserHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Heading } from "@/components/atoms/Heading"
+import { Heading } from "@/components/atoms/Heading/user"
 
 export const UserHeader = (): JSX.Element => {
 

--- a/src/components/layouts/Layout/AdminLayout.tsx
+++ b/src/components/layouts/Layout/AdminLayout.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react"
+import { AdminSidebar } from "../SideBar/AdminSideBar"
+
+type Props = {
+  children: ReactNode
+}
+
+export const AdminLayout = ({ children }: Props) => {
+
+  // MVP: AdminのRecoilStateが空の時はSignInに飛ぶ。
+
+  return (
+    <div className="flex flex-row">
+      <AdminSidebar />
+      <main className="flex w-auto">{children}</main>
+    </div>
+  )
+}

--- a/src/components/layouts/SideBar/AdminSideBar/index.stories.tsx
+++ b/src/components/layouts/SideBar/AdminSideBar/index.stories.tsx
@@ -1,0 +1,15 @@
+import { StoryObj } from "@storybook/react";
+import { AdminSidebar } from ".";
+
+const meta = {
+  title: 'atoms/Heading',
+  component:  AdminSidebar,
+}
+
+export default meta;
+
+type Story = StoryObj<typeof AdminSidebar>;
+
+export const PlainHeading: Story = {
+  render: () => <AdminSidebar />
+}

--- a/src/components/layouts/SideBar/AdminSideBar/index.tsx
+++ b/src/components/layouts/SideBar/AdminSideBar/index.tsx
@@ -1,0 +1,19 @@
+import { AdminHeading } from "@/components/atoms/Heading/admin";
+import { Heading } from "@/components/atoms/Heading/user"
+
+export const AdminSidebar = () => {
+
+  //SideBarに必要なリンクの配列
+  const menuLink = [
+    { 
+
+    },
+  ];
+  
+  return (
+    <div className="flex flex-col w-52 min-h-screen h-full bg-gray-800 text-white">
+      <AdminHeading />
+
+    </div>
+  )
+}

--- a/src/components/molecules/Input/index.tsx
+++ b/src/components/molecules/Input/index.tsx
@@ -42,7 +42,7 @@ export const PlainInput = ({
   labelClassName,
   inputClassName
 }: Props): JSX.Element => (
-  <div className="flex flex-col gap-1 m-2 w-full">
+  <div className="flex flex-col gap-1 w-full">
     <label htmlFor={registerValue} className={labelClassName} >
       {label}
     </label>

--- a/src/feature/owner/components/SignInForm/index.stories.tsx
+++ b/src/feature/owner/components/SignInForm/index.stories.tsx
@@ -1,0 +1,16 @@
+import { StoryObj } from "@storybook/react";
+import { SignInForm } from ".";
+
+
+const meta = {
+  title: 'feature/owner/components/SignInForm',
+  component: SignInForm
+}
+
+export default meta;
+
+type Story = StoryObj<typeof SignInForm>;
+
+export const Form: Story = {
+  render: () => <SignInForm  />
+}

--- a/src/feature/owner/components/SignInForm/index.tsx
+++ b/src/feature/owner/components/SignInForm/index.tsx
@@ -1,0 +1,34 @@
+import { PlainButton } from "@/components/atoms/Button";
+import { PlainInput } from "@/components/molecules/Input";
+import { useForm } from "react-hook-form";
+
+export const SignInForm = (): JSX.Element => {
+  const { handleSubmit, register, formState: {errors}} = useForm();
+  // リファクタ: 型を定義する。
+  const onSubmit = (createData: any): void => {
+    // 次のPRでロジックを作成 -> axios周りを記述する為PRが大きくなる
+    console.log(createData)
+  }
+  
+  return (
+    <form className="flex flex-col w-md space-y-4" onSubmit={handleSubmit(onSubmit)}>
+      <h2 className="font-bold text-xl text-center mb-2">Fill Home</h2>
+      <PlainInput
+        label="メールアドレス"
+        register={register}
+        registerValue="email"
+        inputType="email"
+      />
+      <PlainInput
+        label="パスワード"
+        register={register}
+        registerValue="password"
+        inputType="password"
+      />
+      <PlainButton
+        innerText="ログイン"
+        type="submit"
+      />
+    </form>
+  )
+}

--- a/src/feature/owner/components/SignInSignUpToggle/index.stories.tsx
+++ b/src/feature/owner/components/SignInSignUpToggle/index.stories.tsx
@@ -1,0 +1,15 @@
+import { StoryObj } from "@storybook/react";
+import { SignInSignUpToggle } from ".";
+
+const meta = {
+  title: 'feature/owner/components/SignInSignUpToggle',
+  component: SignInSignUpToggle
+}
+
+export default meta;
+
+type Story = StoryObj<typeof SignInSignUpToggle>;
+
+export const Form: Story = {
+  render: () => <SignInSignUpToggle innerText="テスト" path="/" toggleText="ログイン"  />
+}

--- a/src/feature/owner/components/SignInSignUpToggle/index.tsx
+++ b/src/feature/owner/components/SignInSignUpToggle/index.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+type Props = {
+  innerText: string;
+  path: string;
+  toggleText: '新規登録' | 'ログイン'
+}
+
+export const SignInSignUpToggle = ({ innerText, path, toggleText }: Props): JSX.Element => (
+  <div className="flex flex-col text-center text-sm mt-2">
+    <p className="mt-1">{innerText}{<Link href={path} className="font-bold hover:text-red-500">&nbsp;{toggleText}</Link>}</p>
+  </div>
+)
+
+// アカウント作成の方はこちらから

--- a/src/feature/owner/components/SignUpForm/index.stories.tsx
+++ b/src/feature/owner/components/SignUpForm/index.stories.tsx
@@ -1,0 +1,15 @@
+import { StoryObj } from "@storybook/react";
+import { SignUpForm } from ".";
+
+const meta = {
+  title: 'feature/owner/components/SignUpForm',
+  component: SignUpForm
+}
+
+export default meta;
+
+type Story = StoryObj<typeof SignUpForm>;
+
+export const Form: Story = {
+  render: () => <SignUpForm  />
+}

--- a/src/feature/owner/components/SignUpForm/index.tsx
+++ b/src/feature/owner/components/SignUpForm/index.tsx
@@ -1,0 +1,58 @@
+import { PlainButton } from "@/components/atoms/Button"
+import { PlainInput } from "@/components/molecules/Input"
+import { useForm } from "react-hook-form";
+
+export const SignUpForm = () => {
+  const { handleSubmit, register, formState: {errors}} = useForm();
+  // リファクタ: 型を定義する。
+  const onSubmit = (createData: any): void => {
+    // 次のPRでロジックを作成 -> axios周りを記述する為PRが大きくなる
+    console.log(createData)
+  }
+  
+  return (
+    <form className="flex flex-col w-md space-y-2" onSubmit={handleSubmit(onSubmit)}>
+      <h2 className="font-bold text-xl text-center mb-2">Fill Home</h2>
+      <PlainInput
+        label="メールアドレス"
+        register={register}
+        registerValue="email"
+        inputType="email"
+      />
+      <PlainInput
+        label="パスワード"
+        register={register}
+        registerValue="password"
+        inputType="password"
+      />
+      <div className="flex space-x-2 w-full">
+        <div className="w-1/2">
+          <PlainInput
+            label="苗字"
+            register={register}
+            registerValue="last_name"
+            inputType="text"
+          />
+        </div>
+        <div className="w-1/2">
+          <PlainInput
+            label="名前"
+            register={register}
+            registerValue="first_name"
+            inputType="password"
+          />
+        </div>
+      </div>
+      <PlainInput
+        label="電話番号"
+        register={register}
+        registerValue="phone_number"
+        inputType="tel"
+      />
+      <PlainButton 
+        innerText="新規登録"
+        type="submit"
+      />
+    </form>
+  )
+}

--- a/src/feature/owner/page/SignIn/index.stories.tsx
+++ b/src/feature/owner/page/SignIn/index.stories.tsx
@@ -1,0 +1,16 @@
+import { StoryObj } from "@storybook/react";
+import { OwnerSignIn } from ".";
+
+
+const meta = {
+  title: 'feature/owner/page/SignIn',
+  component: OwnerSignIn
+}
+
+export default meta;
+
+type Story = StoryObj<typeof OwnerSignIn>;
+
+export const Form: Story = {
+  render: () => <OwnerSignIn  />
+}

--- a/src/feature/owner/page/SignIn/index.tsx
+++ b/src/feature/owner/page/SignIn/index.tsx
@@ -1,0 +1,18 @@
+
+import { Routing } from "@/hooks/routing";
+import { SignInForm } from "../../components/SignInForm";
+import { SignInSignUpToggle } from "../../components/SignInSignUpToggle";
+
+export const OwnerSignIn = () => {
+
+  return (
+    <div className="flex flex-col h-screen items-center justify-center ">
+      <SignInForm />
+      <SignInSignUpToggle 
+        innerText='新規登録はこちら'
+        toggleText='新規登録'
+        path={Routing.ownerSignUp.buildRoute().path}
+      />
+    </div>
+  )
+}

--- a/src/feature/owner/page/SignUp/index.stories.tsx
+++ b/src/feature/owner/page/SignUp/index.stories.tsx
@@ -1,0 +1,16 @@
+import { StoryObj } from "@storybook/react";
+import { OwnerSignUp } from ".";
+
+
+const meta = {
+  title: 'feature/owner/page/SignUp',
+  component: OwnerSignUp
+}
+
+export default meta;
+
+type Story = StoryObj<typeof OwnerSignUp>;
+
+export const Form: Story = {
+  render: () => < OwnerSignUp  />
+}

--- a/src/feature/owner/page/SignUp/index.tsx
+++ b/src/feature/owner/page/SignUp/index.tsx
@@ -1,0 +1,14 @@
+import { Routing } from "@/hooks/routing";
+import { SignUpForm } from "../../components/SignUpForm";
+import { SignInSignUpToggle } from "../../components/SignInSignUpToggle";
+
+export const OwnerSignUp = (): JSX.Element => (
+  <div className="flex flex-col h-screen items-center justify-center ">
+    <SignUpForm />
+    <SignInSignUpToggle
+      innerText="アカウントお持ちの方はこちらから"
+      path={Routing.ownerSignIn.buildRoute().path}
+      toggleText="ログイン"
+    />
+  </div>
+)

--- a/src/feature/owner/type.ts/owner.ts
+++ b/src/feature/owner/type.ts/owner.ts
@@ -1,0 +1,8 @@
+
+export type Admin = {
+  email: string,
+  password: string,
+  phone_number: string,
+  last_name: string,
+  first_name: string,
+}

--- a/src/hooks/routing.ts
+++ b/src/hooks/routing.ts
@@ -1,7 +1,12 @@
 import { RoutingType } from "./type";
 
-export const roomPath = '/room'
-export const rentalHouse = '/rentalHouse'
+// admin
+export const baseAdminPath = '/admin'
+export const adminOwnerPath = `${baseAdminPath}/owner`
+
+// user
+export const roomPath = '/room';
+export const rentalHousePath = '/rentalHouse';
 
 // pathをここに追加していく。　
 export const Routing: RoutingType = {
@@ -14,11 +19,12 @@ export const Routing: RoutingType = {
     },
     pathName: 'room詳細',
   },
+
   rentalHouses: {
     buildRoute: () => {
       return {
         id: 'rentalHouses',
-        path: `${rentalHouse}`
+        path: `${rentalHousePath}`
       }
     },
     pathName: 'rentalHouseの一覧'
@@ -27,10 +33,28 @@ export const Routing: RoutingType = {
     buildRoute: ({ houseName }) => {
       return {
         id: 'rentalHousesByHouseName',
-        path: `${rentalHouse}?houseName=${houseName}`
+        path: `${rentalHousePath}?houseName=${houseName}`
       }
     },
     pathName: 'rentalHouseをhotelNameで条件検索'
   },
 
+  ownerSignUp: {
+    buildRoute: () => {
+      return {
+        id: 'ownerSignUp',
+        path: `${adminOwnerPath}/signUp`
+      }
+    },
+    pathName: 'ownerのサインアップ'
+  },
+  ownerSignIn: {
+    buildRoute: () => {
+      return {
+        id: 'ownerSignUp',
+        path: `${adminOwnerPath}/signIn`
+      }
+    },
+    pathName: 'ownerのサインイン'
+  },
 }

--- a/src/hooks/type.ts
+++ b/src/hooks/type.ts
@@ -15,7 +15,15 @@ type RoutingWithNoParams = {
 }
 
 export type RoutingType = {
+  //user
+  //room
   room: RoutingWithParams<{ roomId: number }>;
+  //rentalHouse
   rentalHouses: RoutingWithNoParams;
   rentalHousesByHouseName: RoutingWithParams<{ houseName: string }>;
+
+  //admin
+  //owner
+  ownerSignUp: RoutingWithNoParams;
+  ownerSignIn: RoutingWithNoParams
 }

--- a/src/pages/admin/owner/signIn.tsx
+++ b/src/pages/admin/owner/signIn.tsx
@@ -1,0 +1,7 @@
+import { OwnerSignIn } from "@/feature/owner/page/SignIn"
+
+
+const OwnerSignInPage = (): JSX.Element => <OwnerSignIn />
+
+
+export default OwnerSignInPage

--- a/src/pages/admin/owner/signUp.tsx
+++ b/src/pages/admin/owner/signUp.tsx
@@ -1,0 +1,6 @@
+import { OwnerSignUp } from "@/feature/owner/page/SignUp"
+
+const OwnerSignUpPage = (): JSX.Element => <OwnerSignUp />
+
+
+export default OwnerSignUpPage

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,13 @@ const config: Config = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      width: {
+        'base': '500px',
+        'sm': '440px',
+        'md': '560px',
+        'lg': '770px',
+        'xl': '1280px',
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
 ##概要
ownerの認証画面のUIを作成しました。
ロジックは変更ファイル数が多くなるのでブランチ切り直して取り組みます。

##スクリーンショット
<img width="1728" alt="スクリーンショット 2023-09-11 0 33 01" src="https://github.com/sansan-event-fusion/spark-2023-teamA/assets/85071324/2a187236-9182-48e6-ad93-75bc7000ec8c">
<img width="1728" alt="スクリーンショット 2023-09-11 0 32 56" src="https://github.com/sansan-event-fusion/spark-2023-teamA/assets/85071324/3f09ea3e-8807-4543-bf26-cdf134312952">
