### PR TITLE
[FE]サインアップのロジック追加

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "fillhome-web",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.1",
         "@types/node": "20.5.9",
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",
         "autoprefixer": "10.4.15",
+        "axios": "^1.5.0",
         "eslint": "8.48.0",
         "eslint-config-next": "13.4.19",
         "next": "^13.4.19",
@@ -2929,6 +2931,14 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==",
       "dev": true
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.1.tgz",
+      "integrity": "sha512-K7KCKRKjymxIB90nHDQ7b9nli474ru99ZbqxiqDAWYsYhOsU3/4qLxW91y+1n04ic13ajjZ66L3aXbNef8PELQ==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
@@ -7597,8 +7607,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.15",
@@ -7653,6 +7662,29 @@
       "integrity": "sha512-ZtlVZobOeDQhb/y2lMK6mznDw7TJHDNcKx5/bbBkFvArIQ5CVFhSI6hWWQnMx9I8cNmNmZ30wpDyOC2E2nvgbQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -8713,7 +8745,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -9294,7 +9325,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10912,6 +10942,25 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/for-each": {
@@ -13162,7 +13211,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13171,7 +13219,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -14530,8 +14577,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -19820,6 +19866,12 @@
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==",
       "dev": true
     },
+    "@hookform/resolvers": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.1.tgz",
+      "integrity": "sha512-K7KCKRKjymxIB90nHDQ7b9nli474ru99ZbqxiqDAWYsYhOsU3/4qLxW91y+1n04ic13ajjZ66L3aXbNef8PELQ==",
+      "requires": {}
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
@@ -23104,8 +23156,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "autoprefixer": {
       "version": "10.4.15",
@@ -23129,6 +23180,28 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.0.tgz",
       "integrity": "sha512-ZtlVZobOeDQhb/y2lMK6mznDw7TJHDNcKx5/bbBkFvArIQ5CVFhSI6hWWQnMx9I8cNmNmZ30wpDyOC2E2nvgbQ=="
+    },
+    "axios": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "3.2.1",
@@ -23908,7 +23981,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -24377,8 +24449,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -25684,6 +25755,11 @@
       "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.216.0.tgz",
       "integrity": "sha512-ozczvnbZ++wfBJFseeV0FvINkJ0C6TmRBmb7U7FY1RledNQZuCDTMywRi6txkp8gdzFCJPUxzrU4E27txAktbA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -27317,14 +27393,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -28277,8 +28351,7 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "public-encrypt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.1",
     "@types/node": "20.5.9",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "autoprefixer": "10.4.15",
+    "axios": "^1.5.0",
     "eslint": "8.48.0",
     "eslint-config-next": "13.4.19",
     "next": "^13.4.19",

--- a/src/components/molecules/Input/index.tsx
+++ b/src/components/molecules/Input/index.tsx
@@ -1,25 +1,18 @@
 import { ErrorText } from "@/components/atoms/ErrorText";
 import { FocusEventHandler } from "react";
-import { FieldErrors, FieldValues, UseFormRegister } from "react-hook-form";
+import { UseFormRegister } from "react-hook-form";
 
 //このPlainInputで対応できるtype
 type InputType = 'text' | 'password' | 'tel' | 'email';
 
-type ValidationRules = {
-  required?: string;
-  minLength?: { value: number; message: string };
-  pattern?: { value: RegExp; message: string };
-};
-
 type Props = {
-  registerValue: string;
+  id?: string
+  registerValue?: string;
   label: string;
   inputType: InputType;
   placeholder?: string;
-  register?: UseFormRegister<FieldValues>;
-  errors?: FieldErrors<FieldValues>;
+  register?: UseFormRegister<any>;
   error?: string;
-  rules?: ValidationRules;
   defaultValue?: string;
   onBlur?: FocusEventHandler<HTMLInputElement> | undefined;
   disabled?: boolean;
@@ -28,35 +21,34 @@ type Props = {
 }
 
 export const PlainInput = ({
+  id,
   registerValue,
   label,
   inputType,
   placeholder = '',
   register,
-  errors,
   error,
-  rules,
   defaultValue,
   onBlur,
   disabled = false,
   labelClassName,
-  inputClassName
+  inputClassName,
 }: Props): JSX.Element => (
   <div className="flex flex-col gap-1 w-full">
     <label htmlFor={registerValue} className={labelClassName} >
       {label}
     </label>
     <input 
+      id={id}
       className={
         "border border-gray-300 rounded-md shadow-sm p-2 sm:p-3 w-full focus:outline-pink-color " +
         inputClassName
       }
+      {...(register && register(registerValue ?? ""))}
       type={inputType} 
-      id={registerValue}
       placeholder={placeholder}
       disabled={disabled}
       defaultValue={defaultValue}
-      {...((register && registerValue) && register(registerValue, rules))}
       onBlur={onBlur}
     />
 
@@ -65,10 +57,5 @@ export const PlainInput = ({
         errorText={error}
       />
     )}
-    {/* {errors && errors[registerValue] && (
-      <ErrorText 
-        errorText={errors[registerValue]?.message as string}
-      />
-    )} */}
   </div>
 )

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,1 +1,6 @@
 export const REQUIRE_FIELD = '必須項目です。'
+
+export const FAIL_TO_SIGNUP = '新規登録に失敗しました。'
+export const SUCCESS_TO_SIGNUP = '新規登録に成功しました。'
+
+export const INVALID_EMAIL_FORMAT_MESSAGE = '不正なメールアドレス形式です';

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,6 +1,9 @@
-export const REQUIRE_FIELD = '必須項目です。'
+export const REQUIRE_FIELD = '必須項目です。';
 
-export const FAIL_TO_SIGNUP = '新規登録に失敗しました。'
-export const SUCCESS_TO_SIGNUP = '新規登録に成功しました。'
+export const FAIL_TO_SIGNUP = '新規登録に失敗しました。';
+export const SUCCESS_TO_SIGNUP = '新規登録に成功しました。';
+
+export const SUCCESS_TO_SIGNIN = 'ログインに成功しました。';
+export const FAIL_TO_SIGNIN = 'ログインに失敗しました。';
 
 export const INVALID_EMAIL_FORMAT_MESSAGE = '不正なメールアドレス形式です';

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,9 +1,10 @@
 export const REQUIRE_FIELD = '必須項目です。';
+export const INVALID_EMAIL_FORMAT_MESSAGE = '不正なメールアドレス形式です';
+
+export const EIGHT_CHARACTERS_OR_MORE = '8文字以上で入力してください';
 
 export const FAIL_TO_SIGNUP = '新規登録に失敗しました。';
 export const SUCCESS_TO_SIGNUP = '新規登録に成功しました。';
 
 export const SUCCESS_TO_SIGNIN = 'ログインに成功しました。';
 export const FAIL_TO_SIGNIN = 'ログインに失敗しました。';
-
-export const INVALID_EMAIL_FORMAT_MESSAGE = '不正なメールアドレス形式です';

--- a/src/feature/owner/components/SignInForm/index.tsx
+++ b/src/feature/owner/components/SignInForm/index.tsx
@@ -1,15 +1,37 @@
 import { PlainButton } from "@/components/atoms/Button";
 import { PlainInput } from "@/components/molecules/Input";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
+import { signInInputSchema } from "../../type/schema";
+import { useToast } from "@/hooks/useToast";
+import { useCertainOwner } from "@/hooks/useCertainOwner";
+import { authRepository } from "../../modules/auth/auth.repository";
+import { ToastResult } from "@/type/toast";
 
 export const SignInForm = (): JSX.Element => {
-  const { handleSubmit, register, formState: {errors}} = useForm();
-  // リファクタ: 型を定義する。
+  const { handleSubmit, register, formState: {errors}} = useForm({
+    resolver: zodResolver(signInInputSchema)
+  });
+
+  const { showToast, hideToast } = useToast();
+  const { setOwner, owner } = useCertainOwner();
+
   const onSubmit = (createData: any): void => {
-    // 次のPRでロジックを作成 -> axios周りを記述する為PRが大きくなる
-    console.log(createData)
+    authRepository.signIn(createData)
+      .then(({ data, style, message }: ToastResult) => {
+
+        showToast({ message, style });
+        setTimeout(() => {
+          hideToast();
+          if (style === 'success') {
+            setOwner(data);
+            // TODO: メインページに飛ばす。
+            // return router.push("/")
+          }
+        }, 3000)
+      });
   }
-  
+
   return (
     <form className="flex flex-col w-md space-y-4" onSubmit={handleSubmit(onSubmit)}>
       <h2 className="font-bold text-xl text-center mb-2">Fill Home</h2>
@@ -17,13 +39,18 @@ export const SignInForm = (): JSX.Element => {
         label="メールアドレス"
         register={register}
         registerValue="email"
+        id="email"
         inputType="email"
+        error={errors.email?.message as string}
       />
       <PlainInput
         label="パスワード"
+        {...register('password')}
         register={register}
         registerValue="password"
+        id="password"
         inputType="password"
+        error={errors.password?.message as string}
       />
       <PlainButton
         innerText="ログイン"

--- a/src/feature/owner/components/SignUpForm/index.tsx
+++ b/src/feature/owner/components/SignUpForm/index.tsx
@@ -19,7 +19,6 @@ export const SignUpForm = () => {
   const { setOwner, owner } = useCertainOwner();
 
   const onSubmit = (createData: any): void => {
-     console.log('kakunin',createData)
     authRepository.signUp(createData)
       .then(({ data, style, message }: ToastResult) => {
         console.log(data, style, message)
@@ -32,10 +31,7 @@ export const SignUpForm = () => {
           }
         }, 3000)
       })
-    console.log('提出完了')
   };
-
-  // console.log('確認', owner)
   
   return (
     <form className="flex flex-col w-md space-y-2" onSubmit={handleSubmit(onSubmit)}>

--- a/src/feature/owner/components/SignUpForm/index.tsx
+++ b/src/feature/owner/components/SignUpForm/index.tsx
@@ -1,14 +1,41 @@
 import { PlainButton } from "@/components/atoms/Button"
 import { PlainInput } from "@/components/molecules/Input"
 import { useForm } from "react-hook-form";
+import { authRepository } from "../../modules/auth/auth.repository";
+import { ToastResult } from "@/type/toast";
+import { useToast } from "@/hooks/useToast";
+import { useRouter } from "next/router";
+import { useCertainOwner } from "@/hooks/useCertainOwner";
+import { signUpInputSchema } from "../../type/schema";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 export const SignUpForm = () => {
-  const { handleSubmit, register, formState: {errors}} = useForm();
-  // リファクタ: 型を定義する。
+  const router = useRouter();
+  const { handleSubmit, register, formState: {errors}} = useForm({
+    resolver: zodResolver(signUpInputSchema)
+  });
+
+  const { showToast, hideToast } = useToast();
+  const { setOwner, owner } = useCertainOwner();
+
   const onSubmit = (createData: any): void => {
-    // 次のPRでロジックを作成 -> axios周りを記述する為PRが大きくなる
-    console.log(createData)
-  }
+     console.log('kakunin',createData)
+    authRepository.signUp(createData)
+      .then(({ data, style, message }: ToastResult) => {
+        console.log(data, style, message)
+        showToast({ message, style });
+        setTimeout(() => {
+          hideToast();
+          if (style === 'success') {
+            setOwner(data);
+            // return router.push("/")
+          }
+        }, 3000)
+      })
+    console.log('提出完了')
+  };
+
+  // console.log('確認', owner)
   
   return (
     <form className="flex flex-col w-md space-y-2" onSubmit={handleSubmit(onSubmit)}>
@@ -17,29 +44,38 @@ export const SignUpForm = () => {
         label="メールアドレス"
         register={register}
         registerValue="email"
+        id="email"
         inputType="email"
+        error={errors.email?.message as string}
       />
       <PlainInput
         label="パスワード"
+        {...register('password')}
         register={register}
         registerValue="password"
+        id="password"
         inputType="password"
+        error={errors.password?.message as string}
       />
       <div className="flex space-x-2 w-full">
         <div className="w-1/2">
           <PlainInput
-            label="苗字"
             register={register}
+            id="last_name"
+            label="苗字"
             registerValue="last_name"
             inputType="text"
+            error={errors.last_name?.message as string}
           />
         </div>
         <div className="w-1/2">
           <PlainInput
-            label="名前"
+            id="first_name"
             register={register}
+            label="名前"
             registerValue="first_name"
-            inputType="password"
+            inputType="text"
+            error={errors.first_name?.message as string}
           />
         </div>
       </div>
@@ -47,7 +83,9 @@ export const SignUpForm = () => {
         label="電話番号"
         register={register}
         registerValue="phone_number"
+        id="phone_number"
         inputType="tel"
+        error={errors?.phone_number?.message as string}
       />
       <PlainButton 
         innerText="新規登録"

--- a/src/feature/owner/modules/auth/auth.repository.ts
+++ b/src/feature/owner/modules/auth/auth.repository.ts
@@ -1,16 +1,32 @@
 import { axiosInstance } from "@/lib/axios";
-import { Owner } from "../../type/owner";
 import { AuthRepository } from "../../type/auth.repository";
-import { ToastResult } from "@/type/toast";
-import { FAIL_TO_SIGNUP, SUCCESS_TO_SIGNUP } from "@/constants/messages";
+import { FAIL_TO_SIGNUP, SUCCESS_TO_SIGNIN, SUCCESS_TO_SIGNUP } from "@/constants/messages";
 
 export const authRepository: AuthRepository = {
-  async signUp(createData): Promise<ToastResult<Omit<Owner, 'id'>>> {
+  async signUp(createData) {
     try {
       const res = await axiosInstance.post('/v1/owner/signup', createData);
       return {
         style: 'success',
         message: SUCCESS_TO_SIGNUP,
+        data: res.data
+      }
+    } catch (error: unknown) {
+      const isTypeSafeError = error instanceof Error;
+      return {
+        style: 'failed',
+        message: `${FAIL_TO_SIGNUP}\n${
+          isTypeSafeError ? error.message : ""
+        }`,
+      };
+    }
+  },
+  async signIn(signInData) {
+    try {
+      const res = await axiosInstance.post('/v1/owner/login', signInData);
+      return {
+        style: 'success',
+        message: SUCCESS_TO_SIGNIN,
         data: res.data
       }
     } catch (error: unknown) {

--- a/src/feature/owner/modules/auth/auth.repository.ts
+++ b/src/feature/owner/modules/auth/auth.repository.ts
@@ -1,0 +1,26 @@
+import { axiosInstance } from "@/lib/axios";
+import { Owner } from "../../type/owner";
+import { AuthRepository } from "../../type/auth.repository";
+import { ToastResult } from "@/type/toast";
+import { FAIL_TO_SIGNUP, SUCCESS_TO_SIGNUP } from "@/constants/messages";
+
+export const authRepository: AuthRepository = {
+  async signUp(createData): Promise<ToastResult<Omit<Owner, 'id'>>> {
+    try {
+      const res = await axiosInstance.post('/v1/owner/signup', createData);
+      return {
+        style: 'success',
+        message: SUCCESS_TO_SIGNUP,
+        data: res.data
+      }
+    } catch (error: unknown) {
+      const isTypeSafeError = error instanceof Error;
+      return {
+        style: 'failed',
+        message: `${FAIL_TO_SIGNUP}\n${
+          isTypeSafeError ? error.message : ""
+        }`,
+      };
+    }
+  }
+}

--- a/src/feature/owner/type/auth.repository.ts
+++ b/src/feature/owner/type/auth.repository.ts
@@ -1,0 +1,6 @@
+import { ToastResult } from "@/type/toast";
+import { Owner } from "./owner"
+
+export type AuthRepository = {
+  signUp: (create: Omit<Owner, 'id'>) => Promise<ToastResult<Omit<Owner, 'id'>>>;
+}

--- a/src/feature/owner/type/auth.repository.ts
+++ b/src/feature/owner/type/auth.repository.ts
@@ -2,5 +2,6 @@ import { ToastResult } from "@/type/toast";
 import { Owner } from "./owner"
 
 export type AuthRepository = {
-  signUp: (create: Omit<Owner, 'id'>) => Promise<ToastResult<Omit<Owner, 'id'>>>;
+  signUp: (createData: Omit<Owner, 'id'>) => Promise<ToastResult<Omit<Owner, 'id'>>>;
+  signIn: (signInData: Pick<Owner, 'email' | 'password'>) => Promise<ToastResult<Omit<Owner, 'id'>>>;
 }

--- a/src/feature/owner/type/owner.ts
+++ b/src/feature/owner/type/owner.ts
@@ -1,8 +1,11 @@
 
-export type Admin = {
+export type Owner = {
+  id?: string,
   email: string,
   password: string,
   phone_number: string,
   last_name: string,
   first_name: string,
 }
+
+export type CreateOwner = Owner

--- a/src/feature/owner/type/schema.ts
+++ b/src/feature/owner/type/schema.ts
@@ -1,13 +1,13 @@
-import { INVALID_EMAIL_FORMAT_MESSAGE, REQUIRE_FIELD } from "@/constants/messages";
+import { EIGHT_CHARACTERS_OR_MORE, INVALID_EMAIL_FORMAT_MESSAGE, REQUIRE_FIELD } from "@/constants/messages";
 import * as z from "zod";
 
 //SignUpのschema
 export const signUpInputSchema = z.object({
   email: z.string().email(INVALID_EMAIL_FORMAT_MESSAGE),
-  password: z.string().min(8, "8文字以上で入力してください"),
+  password: z.string().min(8, EIGHT_CHARACTERS_OR_MORE),
   first_name: z.string().min(1, REQUIRE_FIELD),
   last_name: z.string().min(1, REQUIRE_FIELD),
-  phone_number: z.string().min(1, REQUIRE_FIELD)
+  phone_number: z.string().min(1, REQUIRE_FIELD),
   // phone_number: z.string().regex(/^\d{11}$/, '「-」無しで携帯番号をお願いします。')
 });
 export type SignUpInput = z.infer<typeof signUpInputSchema>;

--- a/src/feature/owner/type/schema.ts
+++ b/src/feature/owner/type/schema.ts
@@ -1,0 +1,11 @@
+import { INVALID_EMAIL_FORMAT_MESSAGE, REQUIRE_FIELD } from "@/constants/messages";
+import * as z from "zod";
+
+export const signUpInputSchema = z.object({
+  email: z.string().email(INVALID_EMAIL_FORMAT_MESSAGE),
+  password: z.string().min(8, "8文字以上で入力してください"),
+  first_name: z.string().min(1, REQUIRE_FIELD),
+  last_name: z.string().min(1, REQUIRE_FIELD),
+  phone_number: z.string().regex(/^\d{11}$/, '「-」無しで携帯番号をお願いします。')
+});
+export type SignUpInput = z.infer<typeof signUpInputSchema>;

--- a/src/feature/owner/type/schema.ts
+++ b/src/feature/owner/type/schema.ts
@@ -1,11 +1,20 @@
 import { INVALID_EMAIL_FORMAT_MESSAGE, REQUIRE_FIELD } from "@/constants/messages";
 import * as z from "zod";
 
+//SignUpのschema
 export const signUpInputSchema = z.object({
   email: z.string().email(INVALID_EMAIL_FORMAT_MESSAGE),
   password: z.string().min(8, "8文字以上で入力してください"),
   first_name: z.string().min(1, REQUIRE_FIELD),
   last_name: z.string().min(1, REQUIRE_FIELD),
-  phone_number: z.string().regex(/^\d{11}$/, '「-」無しで携帯番号をお願いします。')
+  phone_number: z.string().min(1, REQUIRE_FIELD)
+  // phone_number: z.string().regex(/^\d{11}$/, '「-」無しで携帯番号をお願いします。')
 });
 export type SignUpInput = z.infer<typeof signUpInputSchema>;
+
+//SignInのschema
+export const signInInputSchema = z.object({
+  email: z.string().email(INVALID_EMAIL_FORMAT_MESSAGE),
+  password: z.string().min(8, "8文字以上で入力してください"),
+});
+export type SignInInput = z.infer<typeof signUpInputSchema>;

--- a/src/hooks/useCertainOwner.ts
+++ b/src/hooks/useCertainOwner.ts
@@ -1,0 +1,12 @@
+import { Owner } from "@/feature/owner/type/owner";
+import { OwnerState, OwnerStateType } from "@/store/owner";
+import { useRecoilState } from "recoil";
+
+export const useCertainOwner = () => {
+  const [ state, setState ] = useRecoilState<OwnerStateType>(OwnerState);
+  const setOwner = (certainOwner: Owner): void => {
+    setState({...state, ...certainOwner});
+  };
+
+  return { setOwner, owner: state }
+};

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,15 +1,20 @@
 import { ToastState } from "@/store/toast";
 import { Toast } from "@/type/toast";
+import { useCallback } from "react";
 import { useRecoilState } from "recoil";
 
 export const useToast = () => {
   const [ state, setState ] = useRecoilState<Toast>(ToastState);
-  const showToast = ({message, style}: Omit<Toast, 'isShown'>): void => {
-    setState({...state, ...{isShown: true, message, style}});
-  };
-  const hideToast = (): void => {
-    setState({...state, ...{isShown:false}})
-  }
-
+  const showToast = useCallback(
+    ({message, style}: Omit<Toast, 'isShown'>): void => {
+      setState({...state, ...{isShown: true, message, style}});
+    },
+    []
+  );
+  const hideToast = useCallback((): void => {
+      setState({...state, ...{isShown:false}})
+    },
+    []
+  );
   return { showToast, hideToast }
 };

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,15 @@
+import { ToastState } from "@/store/toast";
+import { Toast } from "@/type/toast";
+import { useRecoilState } from "recoil";
+
+export const useToast = () => {
+  const [ state, setState ] = useRecoilState<Toast>(ToastState);
+  const showToast = ({message, style}: Omit<Toast, 'isShown'>): void => {
+    setState({...state, ...{isShown: true, message, style}});
+  };
+  const hideToast = (): void => {
+    setState({...state, ...{isShown:false}})
+  }
+
+  return { showToast, hideToast }
+};

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,5 @@
+import axios from "axios";
+
+export const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+});

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,4 +2,5 @@ import axios from "axios";
 
 export const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  withCredentials: true
 });

--- a/src/store/owner/index.ts
+++ b/src/store/owner/index.ts
@@ -1,0 +1,10 @@
+import { Owner } from "@/feature/owner/type/owner";
+import { atom } from "recoil";
+
+//最初の状態をnullにする
+export type OwnerStateType = Owner | null;
+
+export const OwnerState = atom<OwnerStateType>({
+  key: "OwnerState",
+  default: null
+});

--- a/src/store/toast/index.ts
+++ b/src/store/toast/index.ts
@@ -1,0 +1,11 @@
+import { Toast } from "@/type/toast";
+import { atom } from "recoil";
+
+export const ToastState = atom<Toast>({
+  key: "ToastState",
+  default: {
+    isShown: false,
+    message: '',
+    style: 'success'
+  },
+});

--- a/src/type/toast.ts
+++ b/src/type/toast.ts
@@ -1,0 +1,13 @@
+export type ToastStyle = 'success' | 'failed'
+
+export type Toast = {
+  isShown: boolean;
+  message: string;
+  style: ToastStyle;
+}
+
+export type ToastResult<T = any> = {
+  message: string;
+  style: ToastStyle;
+  data?: T;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/feature/owner/type"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
##概要
サインサインアップのロジックを追加しました。
api通信はrepository層で行っています！

MVP1ではownerのrecoilの状態が入っていたら認証成功にしています！
(2以降で変更する必要あり)